### PR TITLE
feat: monthly upload alert

### DIFF
--- a/apps/web/src/components/dashboard/Dashboard.tsx
+++ b/apps/web/src/components/dashboard/Dashboard.tsx
@@ -2,6 +2,7 @@
 
 import { CategoryPieChart } from "@/components/charts/CategoryPieChart";
 import { DashboardLastTransactions } from "@/components/dashboard/DashboardLastTransactions";
+import { MonthlyImportReminder } from "@/components/dashboard/MonthlyImportReminder";
 import { ErrorAlert } from "@/components/ErrorAlert";
 import { StatCard } from "@/components/StatCard";
 import { useDashboardAnalytics } from "@/hooks/analytics/useDashboardAnalytics";
@@ -16,6 +17,7 @@ export const Dashboard = () => {
 
   return (
     <div className="flex flex-col gap-6">
+      {analytics.stats.TRANSACTIONS.value !== 0 && <MonthlyImportReminder />}
       <div className="grid gap-4 grid-cols-1 xl:grid-cols-3">
         <StatCard
           countType={CountType.MONEY}

--- a/apps/web/src/components/dashboard/Dashboard.tsx
+++ b/apps/web/src/components/dashboard/Dashboard.tsx
@@ -17,7 +17,7 @@ export const Dashboard = () => {
 
   return (
     <div className="flex flex-col gap-6">
-      {analytics.stats.TRANSACTIONS.value !== 0 && <MonthlyImportReminder />}
+      {analytics.stats.TRANSACTIONS.value === 0 && <MonthlyImportReminder />}
       <div className="grid gap-4 grid-cols-1 xl:grid-cols-3">
         <StatCard
           countType={CountType.MONEY}

--- a/apps/web/src/components/dashboard/MonthlyImportReminder.tsx
+++ b/apps/web/src/components/dashboard/MonthlyImportReminder.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  AlertTitle,
+} from "@coin-guard/ui";
+import { CalendarClock, X } from "@coin-guard/ui/icons";
+
+import { format, subMonths } from "date-fns";
+
+export const MonthlyImportReminder = () => {
+  const [dismissed, setDismissed] = useState(false);
+  const lastMonth = subMonths(new Date(), 1);
+
+  if (dismissed) {
+    return null;
+  }
+
+  return (
+    <Alert className="border-amber-200 bg-amber-50 text-amber-900">
+      <CalendarClock />
+      <AlertTitle>
+        No transactions for {format(lastMonth, "MMMM yyyy")}
+      </AlertTitle>
+      <AlertDescription className="text-xs">
+        Import your bank statement to keep everything up to date.
+      </AlertDescription>
+      <AlertAction>
+        <X
+          className="cursor-pointer size-4"
+          onClick={() => setDismissed(true)}
+        />
+      </AlertAction>
+    </Alert>
+  );
+};


### PR DESCRIPTION
## Details

Adds a dashboard reminder banner that shows up when no transactions have been recorded for last month, prompting a reminder to import the monthly bank CSV. Since the app relies on a manual monthly import rather than a live bank connection, this makes it obvious at a glance when an import is overdue.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] DB migration
- [ ] Dependency update
- [ ] Other (describe below)

## Changes Made

- Added `MonthlyImportReminder`, a dismissible banner (built on the existing `Alert` component) shown on the Dashboard when last month has zero transactions
- Dismissal is session-only - the banner reappears on the next page load until transactions actually exist for that month
- Wired into `Dashboard.tsx`, reusing the transaction count already fetched for the stat cards (no new query)

## Checklist

- [x] Code follows the project's style guidelines
- [x] No console logs or debug code left behind
- [ ] DB migrations are included (if applicable)
- [x] Tested locally and works as expected
