### PR TITLE
fix: add deterministic tiebreaker to transaction orderBy clauses

### DIFF
--- a/apps/web/src/actions/analytics/dashboard/GetLastTransactions.ts
+++ b/apps/web/src/actions/analytics/dashboard/GetLastTransactions.ts
@@ -4,7 +4,7 @@ import { prisma } from "@coin-guard/db/server";
 
 export const GetLastTransactions = async (amount: number) => {
   const transactions = await prisma.transaction.findMany({
-    orderBy: [{ date: "desc" }, { id: "desc" }],
+    orderBy: [{ date: "desc" }, { description: "asc" }],
     include: {
       account: true,
     },

--- a/apps/web/src/actions/analytics/dashboard/GetLastTransactions.ts
+++ b/apps/web/src/actions/analytics/dashboard/GetLastTransactions.ts
@@ -4,9 +4,7 @@ import { prisma } from "@coin-guard/db/server";
 
 export const GetLastTransactions = async (amount: number) => {
   const transactions = await prisma.transaction.findMany({
-    orderBy: {
-      date: "desc",
-    },
+    orderBy: [{ date: "desc" }, { id: "desc" }],
     include: {
       account: true,
     },

--- a/apps/web/src/actions/bankAccounts/GetBankAccounts.ts
+++ b/apps/web/src/actions/bankAccounts/GetBankAccounts.ts
@@ -3,7 +3,9 @@
 import { prisma } from "@coin-guard/db/server";
 
 export const GetBankAccounts = async () => {
-  const bankAccounts = await prisma.bankAccount.findMany();
+  const bankAccounts = await prisma.bankAccount.findMany({
+    orderBy: { name: "asc" },
+  });
 
   return bankAccounts;
 };

--- a/apps/web/src/actions/categories/GetCategories.ts
+++ b/apps/web/src/actions/categories/GetCategories.ts
@@ -3,7 +3,9 @@
 import { prisma } from "@coin-guard/db/server";
 
 export const GetCategories = async () => {
-  const categories = await prisma.category.findMany();
+  const categories = await prisma.category.findMany({
+    orderBy: { name: "asc" },
+  });
 
   return categories;
 };

--- a/apps/web/src/actions/categories/GetCategory.ts
+++ b/apps/web/src/actions/categories/GetCategory.ts
@@ -13,7 +13,7 @@ export const GetCategory = async (categoryId: string) => {
 
   const transactions = await prisma.transaction.findMany({
     where: { categoryId },
-    orderBy: { date: "asc" },
+    orderBy: [{ date: "asc" }, { description: "asc" }],
     include: { category: true, account: true },
   });
 

--- a/apps/web/src/actions/etl/categories/GetLookupCategories.ts
+++ b/apps/web/src/actions/etl/categories/GetLookupCategories.ts
@@ -12,6 +12,7 @@ export const GetLookupCategories = async () => {
     include: {
       lookups: true,
     },
+    orderBy: { name: "asc" },
   });
 
   return categoriesWithLookups;

--- a/apps/web/src/actions/etl/descriptions/GetLookupDescriptions.ts
+++ b/apps/web/src/actions/etl/descriptions/GetLookupDescriptions.ts
@@ -3,7 +3,9 @@
 import { prisma } from "@coin-guard/db/server";
 
 export const GetLookupDescriptions = async () => {
-  const descriptionLookups = await prisma.lookupDescription.findMany({});
+  const descriptionLookups = await prisma.lookupDescription.findMany({
+    orderBy: { description: "asc" },
+  });
 
   return descriptionLookups;
 };

--- a/apps/web/src/actions/etl/logs/GetLookupLogs.ts
+++ b/apps/web/src/actions/etl/logs/GetLookupLogs.ts
@@ -4,7 +4,7 @@ import { prisma } from "@coin-guard/db/server";
 
 export const GetLookupLogs = async () => {
   const lookupLogs = await prisma.lookupLogging.findMany({
-    orderBy: { createdAt: "desc" },
+    orderBy: [{ createdAt: "desc" }, { description: "asc" }],
   });
 
   return lookupLogs;

--- a/apps/web/src/actions/transactions/GetTransaction.ts
+++ b/apps/web/src/actions/transactions/GetTransaction.ts
@@ -18,7 +18,7 @@ export const GetTransaction = async (transactionId: string) => {
 
     const all = await prisma.transaction.findMany({
       where: { description: transaction.description },
-      orderBy: { date: "asc" },
+      orderBy: [{ date: "asc" }, { id: "asc" }],
       include: {
         category: true,
         account: true,

--- a/apps/web/src/actions/transactions/GetTransaction.ts
+++ b/apps/web/src/actions/transactions/GetTransaction.ts
@@ -18,6 +18,7 @@ export const GetTransaction = async (transactionId: string) => {
 
     const all = await prisma.transaction.findMany({
       where: { description: transaction.description },
+      // description is constant here (filtered above), so id is the tiebreaker
       orderBy: [{ date: "asc" }, { id: "asc" }],
       include: {
         category: true,

--- a/apps/web/src/actions/transactions/GetTransactions.ts
+++ b/apps/web/src/actions/transactions/GetTransactions.ts
@@ -4,7 +4,7 @@ import { prisma } from "@coin-guard/db/server";
 
 export const GetTransactions = async () => {
   const transactions = await prisma.transaction.findMany({
-    orderBy: { date: "desc" },
+    orderBy: [{ date: "desc" }, { id: "desc" }],
     include: {
       category: true,
       account: true,

--- a/apps/web/src/actions/transactions/GetTransactions.ts
+++ b/apps/web/src/actions/transactions/GetTransactions.ts
@@ -4,7 +4,7 @@ import { prisma } from "@coin-guard/db/server";
 
 export const GetTransactions = async () => {
   const transactions = await prisma.transaction.findMany({
-    orderBy: [{ date: "desc" }, { id: "desc" }],
+    orderBy: [{ date: "desc" }, { description: "asc" }],
     include: {
       category: true,
       account: true,


### PR DESCRIPTION
## Summary
- Fixes #100: the transactions table would flicker/reorder same-date rows after an edit-triggered refetch, because `orderBy: { date: "desc" }` has no tiebreaker for rows sharing a date.
- Adds `description` (alphabetical, A→Z) as a secondary sort key to the transaction queries that ordered by `date` alone:
  - `GetTransactions.ts` (main transactions table)
  - `GetLastTransactions.ts` (dashboard widget)
  - `GetCategory.ts` (category detail's transaction list)
  - `GetTransaction.ts` keeps `id` as its tiebreaker instead — that query already filters to a single `description`, so all rows in it share the same value and it wouldn't break ties.
- Same non-determinism exists elsewhere as fully *unordered* lists (no `orderBy` at all, not just a missing tiebreaker) — added alphabetical ordering by `name`/`description`:
  - `GetCategories.ts`, `GetBankAccounts.ts` — order by `name` asc
  - `GetLookupCategories.ts` — order by category `name` asc
  - `GetLookupDescriptions.ts` — order by `description` asc
  - `GetLookupLogs.ts` — kept `createdAt desc` primary, added `description asc` tiebreaker for logs created in the same batch

## Test plan
- [x] `tsc --noEmit` passes in `apps/web`
- [x] `biome lint` passes on changed files
- [ ] Manually verify: edit a transaction that shares its date with other rows and confirm the table order no longer changes across refetches
- [ ] Manually verify: Categories and Bank Accounts lists render alphabetically