### PR TITLE
fix: lookup logs show false ERROR for descriptions that did match

### DIFF
--- a/apps/web/src/actions/etl/TransformDescriptions.ts
+++ b/apps/web/src/actions/etl/TransformDescriptions.ts
@@ -26,31 +26,26 @@ export const TransformDescriptions = async (
     );
   }
 
-  const enhancedTransactions = processedTransactions.map((transaction) => {
-    const newDescription = descriptionToNewDescriptionMap.get(
-      transaction.description,
-    );
+  const matches = processedTransactions.map((transaction) => ({
+    transaction,
+    newDescription: descriptionToNewDescriptionMap.get(transaction.description),
+  }));
 
-    return {
+  const enhancedTransactions = matches.map(
+    ({ transaction, newDescription }) => ({
       ...transaction,
       description: newDescription || transaction.description,
-    };
-  });
+    }),
+  );
 
   await prisma.lookupLogging.createMany({
-    data: enhancedTransactions.map((transaction) => {
-      const newDescription = descriptionToNewDescriptionMap.get(
-        transaction.description,
-      );
-
-      return {
-        type: newDescription ? LoggingType.INFO : LoggingType.ERROR,
-        lookupField: LookupField.DESCRIPTION,
-        description: newDescription
-          ? `Matched '${transaction.description}' → '${newDescription}'`
-          : `No match for '${transaction.description}'`,
-      };
-    }),
+    data: matches.map(({ transaction, newDescription }) => ({
+      type: newDescription ? LoggingType.INFO : LoggingType.ERROR,
+      lookupField: LookupField.DESCRIPTION,
+      description: newDescription
+        ? `Matched '${transaction.description}' → '${newDescription}'`
+        : `No match for '${transaction.description}'`,
+    })),
   });
 
   return enhancedTransactions;


### PR DESCRIPTION
## Summary
- Fixes #101: the Lookup Logs report `ERROR - No match for '<description>'` for descriptions that were actually matched and transformed.
- Root cause in `apps/web/src/actions/etl/TransformDescriptions.ts`: `enhancedTransactions` overwrites `transaction.description` with the matched `newDescription`. The logging step then re-ran the lookup against `enhancedTransactions`, calling `descriptionToNewDescriptionMap.get(transaction.description)` — but by then `description` is already the *new* value, not the raw key the map was built from, so the second lookup always missed for matched transactions.
- Fix: compute the match once per transaction (`{ transaction, newDescription }`) before any overwriting, and derive both the enhanced transaction and its log entry from that single result.
- Checked the sibling `TransformCategories.ts` for the same pattern — it doesn't overwrite `description` (only sets `categoryId`), so its second lookup by `transaction.description` stays valid. No change needed there.

## Test plan
- [x] `tsc --noEmit` passes in `apps/web`
- [x] `biome lint` passes on the changed file
- [ ] Manually verify: import a CSV containing a description that has an enabled `LookupDescription` entry, and confirm the Lookup Logs show `INFO - Matched '<raw>' → '<new>'` instead of `ERROR - No match`