### PR TITLE
feat: default bank account

### DIFF
--- a/apps/web/src/actions/bankAccounts/AddBankAccount.ts
+++ b/apps/web/src/actions/bankAccounts/AddBankAccount.ts
@@ -10,5 +10,19 @@ import { prisma } from "@coin-guard/db/server";
 export const AddBankAccount = async (formValues: addBankAccountSchemaType) => {
   const data = await parseOrThrow(addBankAccountSchema, formValues);
 
-  await prisma.bankAccount.create({ data });
+  const bankAccountsCount = await prisma.bankAccount.count();
+  const isDefault = data.isDefault || bankAccountsCount === 0;
+
+  if (!isDefault) {
+    await prisma.bankAccount.create({ data });
+    return;
+  }
+
+  await prisma.$transaction([
+    prisma.bankAccount.updateMany({
+      data: { isDefault: false },
+      where: { isDefault: true },
+    }),
+    prisma.bankAccount.create({ data: { ...data, isDefault: true } }),
+  ]);
 };

--- a/apps/web/src/actions/bankAccounts/EditBankAccount.ts
+++ b/apps/web/src/actions/bankAccounts/EditBankAccount.ts
@@ -13,8 +13,16 @@ export const EditBankAccount = async (
 ) => {
   const data = await parseOrThrow(editBankAccountSchema, formValues);
 
-  await prisma.bankAccount.update({
-    where: { id: bankAccountId },
-    data,
-  });
+  if (!data.isDefault) {
+    await prisma.bankAccount.update({ where: { id: bankAccountId }, data });
+    return;
+  }
+
+  await prisma.$transaction([
+    prisma.bankAccount.updateMany({
+      data: { isDefault: false },
+      where: { id: { not: bankAccountId }, isDefault: true },
+    }),
+    prisma.bankAccount.update({ where: { id: bankAccountId }, data }),
+  ]);
 };

--- a/apps/web/src/components/bankAccounts/BankAccountAvatar.tsx
+++ b/apps/web/src/components/bankAccounts/BankAccountAvatar.tsx
@@ -1,17 +1,20 @@
-import { Avatar, AvatarFallback } from "@coin-guard/ui";
+import { Avatar, AvatarBadge, AvatarFallback } from "@coin-guard/ui";
 
 type BankAccountAvatarProps = {
   alias: string;
+  isDefault?: boolean;
   size?: "default" | "sm" | "lg";
 };
 
 export const BankAccountAvatar = ({
   alias,
+  isDefault,
   size = "default",
 }: BankAccountAvatarProps) => {
   return (
     <Avatar size={size}>
       <AvatarFallback className="font-bold text-xs">{alias}</AvatarFallback>
+      {isDefault && <AvatarBadge />}
     </Avatar>
   );
 };

--- a/apps/web/src/components/bankAccounts/BankAccountFormFields.tsx
+++ b/apps/web/src/components/bankAccounts/BankAccountFormFields.tsx
@@ -6,6 +6,8 @@ import type {
 } from "@/schemas/bankAccounts";
 import {
   Field,
+  FieldContent,
+  FieldDescription,
   FieldError,
   FieldGroup,
   FieldLabel,
@@ -17,6 +19,7 @@ import {
   SelectLabel,
   SelectTrigger,
   SelectValue,
+  Switch,
 } from "@coin-guard/ui";
 import { Controller, useFormContext } from "react-hook-form";
 
@@ -50,44 +53,46 @@ export const BankAccountFormFields = ({
         )}
       />
 
-      <Controller
-        control={control}
-        name="alias"
-        render={({ field, fieldState }) => (
-          <Field>
-            <FieldLabel htmlFor={`${formId}-alias`}>Alias</FieldLabel>
-            <Input {...field} id={`${formId}-alias`} placeholder="Alias" />
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-          </Field>
-        )}
-      />
+      <FieldGroup className="grid grid-cols-2 gap-4">
+        <Controller
+          control={control}
+          name="alias"
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={`${formId}-alias`}>Alias</FieldLabel>
+              <Input {...field} id={`${formId}-alias`} placeholder="Alias" />
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
 
-      <Controller
-        control={control}
-        name="type"
-        render={({ field, fieldState }) => (
-          <Field>
-            <FieldLabel htmlFor={`${formId}-type`}>Type</FieldLabel>
-            <Select
-              items={bankAccountTypeItems}
-              onValueChange={field.onChange}
-              value={field.value ?? null}
-            >
-              <SelectTrigger className="w-full" id={`${formId}-type`}>
-                <SelectValue placeholder="Bank Account Type" />
-              </SelectTrigger>
-              <SelectContent alignItemWithTrigger={false}>
-                <SelectGroup>
-                  <SelectLabel>Bank Account Type</SelectLabel>
-                  <SelectItem value="CHECKING">Checking</SelectItem>
-                  <SelectItem value="SAVINGS">Savings</SelectItem>
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
-          </Field>
-        )}
-      />
+        <Controller
+          control={control}
+          name="type"
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={`${formId}-type`}>Type</FieldLabel>
+              <Select
+                items={bankAccountTypeItems}
+                onValueChange={field.onChange}
+                value={field.value ?? null}
+              >
+                <SelectTrigger className="w-full" id={`${formId}-type`}>
+                  <SelectValue placeholder="Bank Account Type" />
+                </SelectTrigger>
+                <SelectContent alignItemWithTrigger={false}>
+                  <SelectGroup>
+                    <SelectLabel>Bank Account Type</SelectLabel>
+                    <SelectItem value="CHECKING">Checking</SelectItem>
+                    <SelectItem value="SAVINGS">Savings</SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
+        />
+      </FieldGroup>
 
       <Controller
         control={control}
@@ -96,6 +101,29 @@ export const BankAccountFormFields = ({
           <Field>
             <FieldLabel htmlFor={`${formId}-iban`}>IBAN</FieldLabel>
             <Input {...field} id={`${formId}-iban`} placeholder="IBAN" />
+            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+          </Field>
+        )}
+      />
+
+      <Controller
+        control={control}
+        name="isDefault"
+        render={({ field, fieldState }) => (
+          <Field orientation="horizontal">
+            <FieldContent>
+              <FieldLabel htmlFor={`${formId}-is-default`}>
+                Default account
+              </FieldLabel>
+              <FieldDescription>
+                Pre-selected on new transactions and imports.
+              </FieldDescription>
+            </FieldContent>
+            <Switch
+              checked={field.value ?? false}
+              id={`${formId}-is-default`}
+              onCheckedChange={field.onChange}
+            />
             {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
           </Field>
         )}

--- a/apps/web/src/components/bankAccounts/dialogs/AddBankAccountDialog.tsx
+++ b/apps/web/src/components/bankAccounts/dialogs/AddBankAccountDialog.tsx
@@ -34,6 +34,7 @@ export const AddBankAccountDialog = () => {
       alias: "",
       type: undefined,
       iban: "",
+      isDefault: false,
     },
   });
 
@@ -54,7 +55,7 @@ export const AddBankAccountDialog = () => {
         <PlusCircle />
         Add Bank Account
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent className="max-w-lg!">
         <DialogHeader>
           <DialogTitle>Create Bank Account</DialogTitle>
           <DialogDescription>Create a new bank account</DialogDescription>

--- a/apps/web/src/components/bankAccounts/dialogs/EditBankAccountDialog.tsx
+++ b/apps/web/src/components/bankAccounts/dialogs/EditBankAccountDialog.tsx
@@ -42,6 +42,7 @@ export const EditBankAccountDialog = ({
       alias: bankAccount.alias ?? "",
       type: bankAccount.type,
       iban: bankAccount.iban,
+      isDefault: bankAccount.isDefault,
     },
   });
 
@@ -58,7 +59,7 @@ export const EditBankAccountDialog = ({
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent>
+      <DialogContent className="max-w-lg!">
         <DialogHeader>
           <DialogTitle>Edit Bank Account</DialogTitle>
           <DialogDescription>Edit your bank account details</DialogDescription>

--- a/apps/web/src/components/transactions/ImportTransactions.tsx
+++ b/apps/web/src/components/transactions/ImportTransactions.tsx
@@ -20,7 +20,7 @@ import {
 import { useAtom } from "jotai";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 export const ImportTransactions = () => {
   const router = useRouter();
@@ -30,6 +30,18 @@ export const ImportTransactions = () => {
   const [transactions, setTransactions] = useAtom(processedTransactionsAtom);
 
   const { data: bankAccounts } = useGetBankAccounts();
+
+  useEffect(() => {
+    if (!bankAccounts || accountId) return;
+
+    const defaultBankAccount = bankAccounts.find(
+      (bankAccount) => bankAccount.isDefault,
+    );
+
+    if (defaultBankAccount) {
+      setAccountId(defaultBankAccount.id);
+    }
+  }, [accountId, bankAccounts]);
 
   const { mutateAsync: mutateParse, isPending: parseIsPending } =
     useParseTransaction();

--- a/apps/web/src/components/transactions/TransactionFormFields.tsx
+++ b/apps/web/src/components/transactions/TransactionFormFields.tsx
@@ -32,7 +32,7 @@ import {
 } from "@coin-guard/ui";
 import { CalendarIcon } from "@coin-guard/ui/icons";
 import { format } from "date-fns";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 
 type TransactionSchema = addTransactionSchemaType | editTransactionSchemaType;
@@ -54,7 +54,21 @@ export const TransactionFormFields = ({
 }: TransactionFormFieldsProps) => {
   const { data: categories } = useGetCategories();
   const { data: bankAccounts } = useGetBankAccounts();
-  const { control } = useFormContext<TransactionSchema>();
+  const { control, getValues, setValue } = useFormContext<TransactionSchema>();
+
+  useEffect(() => {
+    if (formType !== FormType.ADD || !bankAccounts || getValues("accountId")) {
+      return;
+    }
+
+    const defaultBankAccount = bankAccounts.find(
+      (bankAccount) => bankAccount.isDefault,
+    );
+
+    if (defaultBankAccount) {
+      setValue("accountId", defaultBankAccount.id);
+    }
+  }, [bankAccounts, formType, getValues, setValue]);
 
   const categoryOptions = useMemo(() => {
     if (!categories) return [];

--- a/apps/web/src/constants/columns/bankAccountColumns.tsx
+++ b/apps/web/src/constants/columns/bankAccountColumns.tsx
@@ -12,11 +12,11 @@ export const bankAccountColumns: ColumnDef<BankAccount>[] = [
     header: "Name",
     size: 510,
     cell: ({ row }) => {
-      const { name, alias, iban } = row.original;
+      const { name, alias, iban, isDefault } = row.original;
 
       return (
         <div className="flex items-center gap-4">
-          <BankAccountAvatar alias={alias ?? ""} />
+          <BankAccountAvatar alias={alias ?? ""} isDefault={isDefault} />
           <div className="flex flex-col">
             <div className="font-medium">{name}</div>
             <div className="text-xs text-muted-foreground">{iban}</div>

--- a/apps/web/src/schemas/bankAccounts.ts
+++ b/apps/web/src/schemas/bankAccounts.ts
@@ -6,6 +6,7 @@ export const addBankAccountSchema = z.object({
   alias: z.string().trim().optional(),
   type: z.enum(BankAccountType),
   iban: z.string().trim().nonempty(),
+  isDefault: z.boolean(),
 });
 
 export const editBankAccountSchema = addBankAccountSchema.partial();

--- a/packages/db/prisma/migrations/20260821100957_add_bank_account_is_default/migration.sql
+++ b/packages/db/prisma/migrations/20260821100957_add_bank_account_is_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "BankAccount" ADD COLUMN     "isDefault" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -65,6 +65,7 @@ model BankAccount {
   alias         String?
   type          BankAccountType
   iban          String            @unique
+  isDefault     Boolean           @default(false)
 
   transactions  Transaction[]
 


### PR DESCRIPTION
## Details

Adds support for marking a bank account as the default one. The default account is now shown with a small indicator in the Bank Accounts table, and it gets pre-selected automatically when adding a transaction or importing a CSV, so you no longer have to pick it every time.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] DB migration
- [ ] Dependency update
- [ ] Other (describe below)

## Changes Made

- Add `isDefault` boolean field to `BankAccount` (migration `add_bank_account_is_default`)
- Add a "Default account" toggle to the Add/Edit Bank Account form; enforced as single-default at the data layer — setting one as default unsets any previous one, and the very first bank account created is automatically marked default
- Show the default account with a small blip on its avatar in the Bank Accounts table
- Widen the Add/Edit Bank Account dialogs and lay out Alias/Type side by side for better use of space
- Pre-select the default bank account on the Add Transaction form and on the CSV import flow (only kicks in when no account has been chosen yet, so it never overrides an explicit selection)

## Checklist

- [x] Code follows the project's style guidelines
- [x] No console logs or debug code left behind
- [x] DB migrations are included (if applicable)
- [x] Tested locally and works as expected
