### PR TITLE
feat: lookup descriptions grouping

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
     "@coin-guard/db": "workspace:*",
     "@coin-guard/ui": "workspace:*",
     "@hookform/resolvers": "^5.4.0",
-    "@stereopt/data-table": "^0.2.6",
+    "@stereopt/data-table": "^0.3.0",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-query-devtools": "^5.101.4",
     "@tanstack/react-table": "^8.21.3",

--- a/apps/web/src/components/etl/UserLookupDescriptions.tsx
+++ b/apps/web/src/components/etl/UserLookupDescriptions.tsx
@@ -5,8 +5,8 @@ import { ErrorAlert } from "@/components/ErrorAlert";
 import { AddLookupDescriptionDialog } from "@/components/etl/dialogs/AddLookupDescriptionDialog";
 import { lookupDescriptionColumns } from "@/constants/columns/lookupDescriptionColumns";
 import { useGetLookupDescriptions } from "@/hooks/etl/descriptions/useGetLookupDescriptions";
-import { DataTable } from "@stereopt/data-table";
 import { TextInitialIcon } from "@coin-guard/ui/icons";
+import { DataTable } from "@stereopt/data-table";
 
 export const UserLookupDescriptions = () => {
   const { data: lookupDescriptions } = useGetLookupDescriptions();
@@ -27,6 +27,17 @@ export const UserLookupDescriptions = () => {
   }
 
   return (
-    <DataTable columns={lookupDescriptionColumns} data={lookupDescriptions} />
+    <DataTable
+      columns={lookupDescriptionColumns}
+      config={{
+        groupBy: "newDescription",
+        columnVisibility: { newDescription: false },
+        search: {
+          filterFields: ["description", "newDescription"],
+          placeholder: "Search lookup descriptions...",
+        },
+      }}
+      data={lookupDescriptions}
+    />
   );
 };

--- a/apps/web/src/constants/columns/lookupDescriptionColumns.tsx
+++ b/apps/web/src/constants/columns/lookupDescriptionColumns.tsx
@@ -5,24 +5,16 @@ import { Badge } from "@coin-guard/ui";
 import type { LookupDescription } from "@coin-guard/db";
 import { cn } from "@coin-guard/ui";
 import type { ColumnDef } from "@tanstack/react-table";
-import { ArrowRight } from "@coin-guard/ui/icons";
 
 export const lookupDescriptionColumns: ColumnDef<LookupDescription>[] = [
   {
     accessorKey: "description",
     header: "Description",
     size: 520,
-    cell: ({ row }) => {
-      const { description, newDescription } = row.original;
-
-      return (
-        <div className="flex items-center gap-2">
-          {description}
-          <ArrowRight className="text-muted-foreground" size={20} />
-          {newDescription}
-        </div>
-      );
-    },
+  },
+  {
+    accessorKey: "newDescription",
+    header: "New description",
   },
   {
     accessorKey: "enabled",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.78.0(react@19.2.8))
       '@stereopt/data-table':
-        specifier: ^0.2.6
-        version: 0.2.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^0.3.0
+        version: 0.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-query':
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
@@ -1112,8 +1112,8 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
-  '@stereopt/data-table@0.2.6':
-    resolution: {integrity: sha512-EhXdMdC4HhGoaiAAw/xu2QZnlJvTNAFG8L4oolS8qzZrC4fywgaKc9g80g2ImXSfjGJjC2kOcQ7zMnowfp6pFg==}
+  '@stereopt/data-table@0.3.0':
+    resolution: {integrity: sha512-zvafntOit3ZT4iUTxd3Mx4jyRVMDJvu/2bFAcWKfXRFlNKCXUMPziXyeN/fCXAnXV5ucklsqsrp46+x70HMR/Q==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -2899,11 +2899,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -4064,14 +4059,14 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@stereopt/data-table@0.2.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@stereopt/data-table@0.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tailwindcss/postcss': 4.3.3
       '@tanstack/match-sorter-utils': 8.19.4
       '@tanstack/react-table': 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority: 0.7.1
       clsx: 2.1.1
-      postcss: 8.5.22
+      postcss: 8.5.23
       react: 19.2.8
       react-day-picker: 9.14.0(react@19.2.8)
       react-dom: 19.2.8(react@19.2.8)
@@ -5287,7 +5282,7 @@ snapshots:
 
   node-abi@3.89.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
     optional: true
 
   node-releases@2.0.38: {}
@@ -5734,9 +5729,6 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
-
-  semver@7.7.4:
-    optional: true
 
   semver@7.8.5:
     optional: true


### PR DESCRIPTION
## Details

Lookup Descriptions were shown as a flat, one-row-per-entry table, so rows mapping to the same `newDescription` weren't grouped — making it hard to see everything already being transformed into a given value at a glance. This adds a grouped view (section-header rows by `newDescription`, with per-group counts) and a search box, built on the new `groupBy` support in `@stereopt/data-table@0.3.0`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] DB migration
- [x] Dependency update
- [ ] Other (describe below)

## Changes Made

- Bump `@stereopt/data-table` to `^0.3.0` to pick up its new `groupBy` config option
- Group the Lookup Descriptions table by `newDescription`, with the grouping column hidden via `columnVisibility`
- Simplify the `description` column to show just the source value (the group header now carries `newDescription`)
- Add a search box filtering across both `description` and `newDescription`
- No changes to per-row add/edit/delete/apply actions or to the underlying schema — display only

## Checklist

- [x] Code follows the project's style guidelines
- [x] No console logs or debug code left behind
- [ ] DB migrations are included (if applicable)
- [x] Tested locally and works as expected
